### PR TITLE
fixed a bug in decodeVariableLengthValue(). it treated 128 as end of …

### DIFF
--- a/SMFreader.js
+++ b/SMFreader.js
@@ -62,7 +62,7 @@ function decodeVariableLengthValue(data, trackOffset ) {
 		i = data.getUint8(idx++);
 		result = result << 7;		// left-shift by 7 bits
 		result += (i & 0x7f);	// mask off the top bit
-	} while (i>0x80);
+	} while (i>=0x80);
 	
 	return {idx:idx,result:result};
 }


### PR DESCRIPTION
…sequence but there actually may exist numbers, say 704513 that would actually have 7 zero bits in a row. now i can open my midi file, yipie!
